### PR TITLE
Add svg fill rule for to support SVG <use> and <symbol> for Firefox

### DIFF
--- a/src/core-css.css
+++ b/src/core-css.css
@@ -9,6 +9,7 @@ html {
   -webkit-tap-highlight-color: transparent;
 }
 body, img, svg, a { margin: 0; border: 0; color: inherit; fill: currentColor }
+svg > use > svg {  fill: inherit; } /* Workaround for FF bug: https://bugzilla.mozilla.org/show_bug.cgi?id=265894 */
 button, select, a, input, label, textarea { touch-action: manipulation } /* FastClick */
 button, select { cursor: pointer }
 


### PR DESCRIPTION
Fixes #10.

This is a workaround for a Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=265894.
The problem is explained in depth here: http://stackoverflow.com/questions/27866893/svg-fill-not-being-applied-in-firefox.