### PR TITLE
Remove static-publish-cli as an optional depdency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
   "bugs": {
     "url": "https://github.com/nrkno/core-css/issues"
   },
-  "optionalDependencies": {
-    "@nrk/static-publish-cli": "^3.0.2"
-  },
   "devDependencies": {
     "cpx": "^1.5.0",
     "eslint": "^3.18.0",


### PR DESCRIPTION
Fixes #20.

Yarn has no option (?) for installing a dependency without its optional dependencies.
Since static publish-cli is an internal NRK package it will fail to fetch it outside
of NRK. Yarn handles doesn't handle 404 on optional packages as NPM does and
installation fails.