### PR TITLE
sørge for samme høyde på input-elementer

### DIFF
--- a/lib/core-css.css
+++ b/lib/core-css.css
@@ -175,6 +175,7 @@ button,  a { touch-action: manipulation }
   font-family: inherit;
   font-size: inherit;
   line-height: 1.5; /* Makes input[type="file"] equal height as other inputs */
+  height: 2.6em;    /* Makes all textual inputs same height. This and line-height is needed for that. */
   box-shadow: 0 0 0 1px rgba(0,0,0,.15); /* IE11 doesn't render border on checkbox and radio */
   border-radius: 4px;
   padding: .5em .7em;
@@ -185,14 +186,10 @@ button,  a { touch-action: manipulation }
 .nrk-input:disabled { opacity: .5; cursor: not-allowed !important }
 .nrk-input[readonly] { opacity: .8; cursor: default !important }
 
-.nrk-input::-ms-clear, /* reset IE search clear */
 .nrk-input::-ms-expand, /* reset IE select arrow */
-.nrk-input::-ms-reveal, /* reset IE password reveal */
 .nrk-input::-ms-check { /* reset IE checkbox check */
   display: none;
 }
-
-.nrk-input[type="file"] { cursor: pointer }
 .nrk-input::-ms-value { /* reset IE input[type="file"] text style  */
   background: none;
   color: inherit;
@@ -202,13 +199,7 @@ button,  a { touch-action: manipulation }
   border: 0;
 }
 
-/* hides number arrows in FireFox */
-.nrk-input[type="number"] { -moz-appearance: textfield }
-
-/* hides number arrows in chrome, safari */
-.nrk-input::-webkit-outer-spin-button,
-.nrk-input::-webkit-inner-spin-button { -webkit-appearance: none }
-
+.nrk-input[type="file"] { cursor: pointer }
 
 .nrk-input[type="radio"] { border-radius: 100% }
 .nrk-input[type="radio"],
@@ -251,13 +242,18 @@ the foreground and background color on the element */
 }
 
 textarea.nrk-input {
+  height: auto;
   overflow: auto; /* Consistenly show scrollbar */
   resize: vertical; /* Prevent horizontally resizable textarea */
   vertical-align: top;
   line-height: inherit;
 }
 
-select.nrk-input[multiple] { vertical-align: top }
+select.nrk-input[multiple] {
+  height: auto;
+  vertical-align: top;
+}
+
 select.nrk-input:not([multiple]) {
   background-image:
     linear-gradient(45deg, transparent 46%, currentcolor 47%, currentcolor 49%, transparent 51%),

--- a/lib/readme.md
+++ b/lib/readme.md
@@ -332,6 +332,10 @@ functional form layout.
       <input class="nrk-input nrk-xs-12of12" type="search" placeholder="Search">
     </label>
     <label class="nrk-xs-12of12 nrk-lg-4of12">
+      Time
+      <input class="nrk-input nrk-xs-12of12" type="time" placeholder="Time">
+    </label>
+    <label class="nrk-xs-12of12 nrk-lg-4of12">
       Number
       <input class="nrk-input nrk-xs-12of12" type="number" placeholder="Number">
     </label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,7 +209,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -689,7 +689,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -944,7 +944,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -1293,7 +1293,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -2052,7 +2052,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -2064,7 +2064,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -2505,7 +2505,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -3728,7 +3728,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -3856,7 +3856,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },


### PR DESCRIPTION
som sett i https://github.com/nrkno/origo/issues/224 så blir input-felt høyde litt anerledes basert på type og nettleser. se også https://joshnh.com/weblog/line-height-doesnt-work-as-expected-on-inputs/

løsning:
* sett `height` eksplisitt på `<input>`. satt i `em` så den skalerer med font-str.
* ekstra: ikke ta bort clear-knapp og piler for enkelte typer input
* ser ok ut i ie11, safari,chrome,ff,edge

før (i chrome):

<img width="593" alt="image" src="https://user-images.githubusercontent.com/1709263/68769110-10e12000-0624-11ea-8f25-da21d39e3677.png">

etter (i chrome):
<img width="602" alt="image" src="https://user-images.githubusercontent.com/1709263/68769122-16d70100-0624-11ea-8f6a-0e390ec4d347.png">
