### PR TITLE
update: visually-hidden content class definition

### DIFF
--- a/lib/core-css.css
+++ b/lib/core-css.css
@@ -384,4 +384,5 @@ select.nrk-input:not([multiple]) {
   width: 1px !important;
   height: 1px !important;
   clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
 }

--- a/lib/core-css.css
+++ b/lib/core-css.css
@@ -384,5 +384,6 @@ select.nrk-input:not([multiple]) {
   width: 1px !important;
   height: 1px !important;
   clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
   white-space: nowrap !important;
 }


### PR DESCRIPTION
The `.nrk-sr` rule is outdated.

1. `white-space: nowrap` preserves screen reader fluency
2. `clip-path` should be used along with deprecated `clip`

https://www.tpgi.com/the-anatomy-of-visually-hidden/